### PR TITLE
Update compat entry for ChunkSplitters

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
-ChunkSplitters = "1"
+ChunkSplitters = "1, 2"
 StaticArrays = "1"
 julia = "1.6"
 


### PR DESCRIPTION
We released a formally breaking version of ChunkSplitters (v2.0.0), but which does not affect most users. It won´t affect your package, so here I'm proposing the update of the compat entry to accept the 2.0 version.